### PR TITLE
[Fix] VScode configuration 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,12 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
   },


### PR DESCRIPTION
- chore: add `markdown` and `javascriptreact` vscode `defaultFormatter`