### PR TITLE
[Feature] Add end-to-end test with `Maestro`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ docs/docs/api
 # Storybook
 #
 build-storybook.log
+
+# Builds
+#
+builds/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,6 +104,11 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
+        maestro {
+            initWith debug
+            matchingFallbacks = ['debug']
+            debuggable true
+        }
     }
 }
 

--- a/android/app/src/main/java/com/project/MainApplication.kt
+++ b/android/app/src/main/java/com/project/MainApplication.kt
@@ -28,6 +28,14 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        override fun getJSBundleFile(): String? {
+          return if (BuildConfig.BUILD_TYPE == "maestro") {
+            "assets://main.jsbundle"
+          } else {
+            super.getJSBundleFile()
+          }
+        }
       }
 
   override val reactHost: ReactHost

--- a/e2e/android/counting-flow-android.yaml
+++ b/e2e/android/counting-flow-android.yaml
@@ -1,0 +1,24 @@
+appId: com.project
+---
+- launchApp
+- assertVisible: '0'
+
+- tapOn:
+    text: '+'
+    waitToSettleTimeoutMs: 0
+- assertVisible: 'loading'
+- assertVisible: '1'
+
+- stopApp
+- launchApp
+- assertVisible: '1'
+
+- tapOn:
+    text: '-'
+    waitToSettleTimeoutMs: 0
+- assertVisible: 'loading'
+- assertVisible: '0'
+
+- stopApp
+- launchApp
+- assertVisible: '0'

--- a/e2e/ios/counting-flow-ios.yaml
+++ b/e2e/ios/counting-flow-ios.yaml
@@ -1,0 +1,24 @@
+appId: org.reactjs.native.example.Project
+---
+- launchApp
+- assertVisible: '0'
+
+- tapOn:
+    text: '+'
+    waitToSettleTimeoutMs: 0
+- assertVisible: 'loading'
+- assertVisible: '1'
+
+- stopApp
+- launchApp
+- assertVisible: '1'
+
+- tapOn:
+    text: '-'
+    waitToSettleTimeoutMs: 0
+- assertVisible: 'loading'
+- assertVisible: '0'
+
+- stopApp
+- launchApp
+- assertVisible: '0'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,6 +14,12 @@ if linkage != nil
   use_frameworks! :linkage => linkage.to_sym
 end
 
+project 'Project.xcodeproj', {
+  'Debug' => :debug,
+  'Release' => :release,
+  'Maestro' => :debug
+}
+
 target 'Project' do
   config = use_native_modules!
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FBLazyVector (0.77.1)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.77.0):
-    - hermes-engine/Pre-built (= 0.77.0)
-  - hermes-engine/Pre-built (0.77.0)
+  - hermes-engine (0.77.1):
+    - hermes-engine/Pre-built (= 0.77.1)
+  - hermes-engine/Pre-built (0.77.1)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2073,7 +2073,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 1f783c3d53940aed0d2c84586f0b7a85ab7827ef
+  hermes-engine: ccc24d29d650ea725d582a9a53d57cd417fbdb53
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 664055db806cce35c3c1b43c84414dd66e117ae6
   RCTRequired: dc9a83fa1012054f94430d210337ca3a1afe6fc0
@@ -2142,6 +2142,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 2957d0e744897870b5a377f26522e3f08cadd7ac
 
-PODFILE CHECKSUM: 023830d712b1d1fa429ec62e6ae07f2cd94a001d
+PODFILE CHECKSUM: dcd021a67f92e654d6cda097c8b48c1361bee45e
 
 COCOAPODS: 1.16.2

--- a/ios/Project.xcodeproj/project.pbxproj
+++ b/ios/Project.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Project/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Project/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = Project/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		69A46B1EB79E092EE6D558BD /* Pods-Project.maestro.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Project.maestro.xcconfig"; path = "Target Support Files/Pods-Project/Pods-Project.maestro.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Project/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B983758B5052DFD59B60EB58 /* libPods-Project.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Project.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA95F38F2D45678100BBD7BE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Project/AppDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +114,7 @@
 			children = (
 				E9F62EF50CBD43C297EC6EDF /* Pods-Project.debug.xcconfig */,
 				DE9A0AAD6BFB0DB362526A5A /* Pods-Project.release.xcconfig */,
+				69A46B1EB79E092EE6D558BD /* Pods-Project.maestro.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -572,6 +574,141 @@
 			};
 			name = Release;
 		};
+		DA6A3A2F2E0C4B3000B2183F /* Maestro */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"MAESTRO=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(SDKROOT)/usr/lib/swift\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+					"-DFOLLY_CFG_NO_COROUTINES=1",
+					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG MAESTRO";
+				USE_HERMES = true;
+			};
+			name = Maestro;
+		};
+		DA6A3A302E0C4B3000B2183F /* Maestro */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 69A46B1EB79E092EE6D558BD /* Pods-Project.maestro.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				INFOPLIST_FILE = Project/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = Project;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Maestro;
+		};
+		DA6A3A312E0C4B3000B2183F /* Maestro */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = ProjectTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Project.app/Project";
+			};
+			name = Maestro;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -579,6 +716,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				00E356F61AD99517003FC87E /* Debug */,
+				DA6A3A312E0C4B3000B2183F /* Maestro */,
 				00E356F71AD99517003FC87E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -588,6 +726,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				13B07F941A680F5B00A75B9A /* Debug */,
+				DA6A3A302E0C4B3000B2183F /* Maestro */,
 				13B07F951A680F5B00A75B9A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -597,6 +736,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,
+				DA6A3A2F2E0C4B3000B2183F /* Maestro */,
 				83CBBA211A601CBA00E9B192 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/ios/Project/AppDelegate.swift
+++ b/ios/Project/AppDelegate.swift
@@ -21,10 +21,12 @@ class AppDelegate: RCTAppDelegate {
   }
 
   override func bundleURL() -> URL? {
-#if DEBUG
-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#if MAESTRO
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#elseif DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
 #else
-    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "jest": "jest --runInBand --verbose --noStackTrace",
     "jest:watch": "npm run jest -- --watch",
     "jest:coverage": "npm run jest -- --coverage",
+    "maestro:ios:build": "bash ./scripts/bundle_maestro_ios.sh",
     "react-native": "react-native start --reset-cache --client-logs",
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "is-ci-cli \"test:coverage\" \"test:watch\"",
     "test:watch": "npm run jest:watch",
     "test:coverage": "npm-run-all --parallel jest:coverage storybook:test:coverage",
+    "test:e2e:ios": "APP_PATH=$(npm run maestro:ios:build  | tee /dev/stderr | tail -n 1) && npm run maestro:ios -- -a \"$APP_PATH\"",
     "jest": "jest --runInBand --verbose --noStackTrace",
     "jest:watch": "npm run jest -- --watch",
     "jest:coverage": "npm run jest -- --coverage",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "jest": "jest --runInBand --verbose --noStackTrace",
     "jest:watch": "npm run jest -- --watch",
     "jest:coverage": "npm run jest -- --coverage",
+    "maestro:ios": "bash ./scripts/run_maestro_ios.sh",
     "maestro:ios:build": "bash ./scripts/bundle_maestro_ios.sh",
     "react-native": "react-native start --reset-cache --client-logs",
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jest:coverage": "npm run jest -- --coverage",
     "maestro:ios": "bash ./scripts/run_maestro_ios.sh",
     "maestro:ios:build": "bash ./scripts/bundle_maestro_ios.sh",
+    "maestro:android": "bash ./scripts/run_maestro_android.sh",
     "maestro:android:build": "bash ./scripts/bundle_maestro_android.sh",
     "react-native": "react-native start --reset-cache --client-logs",
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "npm run jest:watch",
     "test:coverage": "npm-run-all --parallel jest:coverage storybook:test:coverage",
     "test:e2e:ios": "APP_PATH=$(npm run maestro:ios:build  | tee /dev/stderr | tail -n 1) && npm run maestro:ios -- -a \"$APP_PATH\"",
+    "test:e2e:android": "APP_PATH=$(npm run maestro:android:build  | tee /dev/stderr | tail -n 1) && npm run maestro:android -- -a \"$APP_PATH\"",
     "jest": "jest --runInBand --verbose --noStackTrace",
     "jest:watch": "npm run jest -- --watch",
     "jest:coverage": "npm run jest -- --coverage",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jest:coverage": "npm run jest -- --coverage",
     "maestro:ios": "bash ./scripts/run_maestro_ios.sh",
     "maestro:ios:build": "bash ./scripts/bundle_maestro_ios.sh",
+    "maestro:android:build": "bash ./scripts/bundle_maestro_android.sh",
     "react-native": "react-native start --reset-cache --client-logs",
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/scripts/bundle_maestro_android.sh
+++ b/scripts/bundle_maestro_android.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+ANDROID_DIR="./android/app/src/main"
+CONFIGURATION="Maestro"
+APP_NAME="app-$(echo "$CONFIGURATION" | tr '[:upper:]' '[:lower:]').apk"
+BUILD_PATH="./android/app/build"
+OUTPUT_FOLDER_PATH="./builds/debug"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -o|--output) OUTPUT_FOLDER_PATH="$2"; shift ;;
+    *) echo "❌ Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+OUTPUT_APP_PATH="$OUTPUT_FOLDER_PATH/$APP_NAME"
+BUNDLE_OUTPUT="$ANDROID_DIR/assets/main.jsbundle"
+
+echo "🔧 Generating main.jsbundle..."
+npx react-native bundle \
+  --platform android \
+  --entry-file index.js \
+  --dev true \
+  --bundle-output "$BUNDLE_OUTPUT" \
+  --assets-dest "$ANDROID_DIR/res"
+
+echo "🛠️ Building app for simulator..."
+rm -rf android/.gradle \
+      android/.cxx \
+      android/app/.cxx \
+      android/app/build \
+      .gradle \
+      .cxx\
+      $ANDROID_DIR/res/drawable-mdpi \
+      $BUILD_PATH
+
+./android/gradlew -p android clean assemble$CONFIGURATION
+
+echo "📦 Copying app to build directory..."
+BUILT_APP="$BUILD_PATH/outputs/apk/$(echo "$CONFIGURATION" | tr '[:upper:]' '[:lower:]')/$APP_NAME"
+
+if [[ ! -f "$BUILT_APP" ]]; then
+  echo "❌ Build failed: .apk not found at $BUILT_APP"
+  exit 1
+fi
+
+echo "$BUILT_APP"
+echo "$OUTPUT_APP_PATH"
+mv "$BUILT_APP" "$OUTPUT_APP_PATH"
+echo "📍 App available at: $OUTPUT_APP_PATH"
+
+echo "🧹 Cleaning..."
+./android/gradlew -p android clean
+rm -rf android/.gradle \
+      android/.cxx \
+      android/app/.cxx \
+      android/app/build \
+      .gradle \
+      .cxx\
+      $BUILD_PATH \
+      $BUNDLE_OUTPUT \
+      $ANDROID_DIR/res/drawable-mdpi
+
+echo "✅ App compiled successfully!"
+echo "$OUTPUT_APP_PATH"

--- a/scripts/bundle_maestro_ios.sh
+++ b/scripts/bundle_maestro_ios.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# set -e
+
+IOS_DIR="ios"
+SCHEME="Project"
+CONFIGURATION="Maestro"
+APP_NAME="Project.app"
+WORKSPACE="$IOS_DIR/Project.xcworkspace"
+SDK="iphonesimulator"
+OUTPUT_DIR_PATH="./builds/debug"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -o|--output) OUTPUT_DIR_PATH="$2"; shift ;;
+    *) echo "❌ Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+OUTPUT_FOLDER_PATH="$OUTPUT_DIR_PATH/temp"
+OUTPUT_APP_PATH="$OUTPUT_DIR_PATH/$APP_NAME"
+
+echo "🔧 Generating main.jsbundle..."
+npx react-native bundle \
+  --platform ios \
+  --entry-file index.js \
+  --dev true \
+  --bundle-output "$IOS_DIR/main.jsbundle" \
+  --assets-dest "$IOS_DIR"
+
+echo "🛠️ Building app for simulator..."
+rm -rf "$OUTPUT_FOLDER_PATH"
+xcrun xcodebuild \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIGURATION" \
+  -sdk "$SDK" \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath "$OUTPUT_FOLDER_PATH" \
+  build
+
+
+
+echo "📦 Copying app to build directory..."
+BUILT_APP="$OUTPUT_FOLDER_PATH/Build/Products/$CONFIGURATION-iphonesimulator/$APP_NAME"
+
+if [[ ! -d "$BUILT_APP" ]]; then
+  echo "❌ Build failed: .app not found at $BUILT_APP"
+  exit 1
+fi
+
+rm -rf "$OUTPUT_APP_PATH"
+mkdir -p "$OUTPUT_DIR_PATH"
+mv "$BUILT_APP" "$OUTPUT_APP_PATH"
+echo "📍 App available at: $OUTPUT_APP_PATH"
+
+echo "🧹 Cleaning..."
+rm -rf "$IOS_DIR/assets"
+rm -rf "$OUTPUT_FOLDER_PATH"
+
+echo "✅ App compiled successfully!"
+
+echo "$OUTPUT_APP_PATH"

--- a/scripts/run_maestro_android.sh
+++ b/scripts/run_maestro_android.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+AVD_NAME=""
+FLOW_PATH="./e2e/android"
+APP_PATH=""
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -d|--device) AVD_NAME="$2"; shift ;;
+    -f|--flow) FLOW_PATH="$2"; shift ;;
+    -a|--app) APP_PATH="$2"; shift ;;
+    *) echo "❌ Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ -z "$APP_PATH" ]]; then
+  echo "❌ Missing required argument: --app <path-to-.app>"
+  exit 1
+fi
+
+echo "📱 Installing on simulator..."
+
+DEVICE_ID=$(adb devices | grep -w "device" | awk '{print $1}' | head -n 1)
+
+if [[ -z "$DEVICE_ID" ]]; then
+  echo "⚠️ No booted device found. Booting the first available one..."
+  AVD_NAME=$(emulator -list-avds | head -n 1)
+  nohup emulator -avd "$AVD_NAME" -no-audio -no-window -no-boot-anim > /dev/null 2>&1 &
+
+  echo "⏳ Waiting for emulator to boot..."
+  until adb shell getprop sys.boot_completed | grep -m 1 "1" > /dev/null; do
+    sleep 1
+  done
+
+  echo "✅ Emulator booted!"
+  DEVICE_ID=$(adb devices | grep -w "device" | awk '{print $1}' | head -n 1)
+else
+  AVD_NAME=$(adb -s "$DEVICE_ID" emu avd name)
+fi
+
+echo "ℹ️ Using simulator ID: $DEVICE_ID($AVD_NAME)"
+
+echo "📱 Installing on simulator..."
+adb -s "$DEVICE_ID" install -r "$APP_PATH"
+
+# # Run Maestro test
+echo "▶️ Running Maestro test on '$FLOW_PATH' using device '$AVD_NAME'"
+maestro --device "$DEVICE_ID" test "$FLOW_PATH"
+
+echo "🛑 Shutting down simulator..."
+adb -s "$DEVICE_ID" emu kill

--- a/scripts/run_maestro_ios.sh
+++ b/scripts/run_maestro_ios.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+SIMULATOR_ID=""
+FLOW_PATH="./e2e/ios"
+APP_PATH=""
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -d|--device) SIMULATOR_ID="$2"; shift ;;
+    -f|--flow) FLOW_PATH="$2"; shift ;;
+    -a|--app) APP_PATH="$2"; shift ;;
+    *) echo "❌ Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ -z "$APP_PATH" ]]; then
+  echo "❌ Missing required argument: --app <path-to-.app>"
+  exit 1
+fi
+
+echo "📱 Installing on simulator..."
+if [[ -z "$SIMULATOR_ID" ]]; then
+  echo "⚠️ No booted device found. Booting the first available one..."
+  SIMULATOR_ID=$(xcrun simctl list devices available | grep -E 'iPhone|iPad' | sed -E 's/.*\(([-A-F0-9]{36})\).*/\1/i' | head -n 1)
+fi
+
+if [ -z "$SIMULATOR_ID" ]; then
+  echo "❌ No available simulator found. Please start a simulator first."
+  exit 1
+fi
+
+echo "ℹ️ Using simulator ID: $SIMULATOR_ID"
+
+# Check if the simulator is already booted
+IS_BOOTED=$(xcrun simctl list devices booted | grep "$SIMULATOR_ID")
+
+if [ -z "$IS_BOOTED" ]; then
+  echo "🚀 Booting simulator..."
+  xcrun simctl boot "$SIMULATOR_ID"
+else
+  echo "✅ Simulator is already booted."
+fi
+
+# Install and shutdown
+echo "📦 Installing app at path: $APP_PATH"
+xcrun simctl install $SIMULATOR_ID "$APP_PATH"
+
+# # Run Maestro test
+echo "▶️ Running Maestro test on '$FLOW_PATH' using device '$SIMULATOR_ID'"
+maestro --device "$SIMULATOR_ID" test "$FLOW_PATH"
+
+echo "🛑 Shutting down simulator..."
+xcrun simctl shutdown "$SIMULATOR_ID"


### PR DESCRIPTION
- test: add `Maestro` build configuration for `ios`
- build: add `maestro:ios:build` script  for build `maestro` app
- build: add  `test:e2e:ios` script
- test: add `counting` flow end-to-end `ios` test
- test: add `maestro` build configuration for `android`
- build: add `maestro:android:build` script for building `maestro` app
- build: add `test:e2e:android` script
- test: add `counting` flow end-to-end `android` test
- chore: add `builds`  to `.gitignore`
